### PR TITLE
Use Nested options validator as priority validator

### DIFF
--- a/src/decorators.ts
+++ b/src/decorators.ts
@@ -52,7 +52,7 @@ type NestedOptions = Partial<RuleCustom> & { validator?: Class<any> };
 
 export function Nested (options: NestedOptions = {}): any {
   return (target: Class<any>, key: string): any => {
-    const t = Reflect.getMetadata("design:type", target, key) ?? options.validator;
+    const t = options.validator ?? Reflect.getMetadata("design:type", target, key);
     if (!t) {
       throw new Error(`Cannot get \"design:type\" of ${key}. Please use the validator option to @Nested`); 
     }

--- a/tests/validator.test.ts
+++ b/tests/validator.test.ts
@@ -492,7 +492,30 @@ describe("Array", () => {
 });
 
 describe("Nested", () => {
-  it("Should apply nested schema", () => {
+  it("Should apply nested schema as field validator", () => {
+    @Schema({ strict: true })
+    class NestedTest {
+      @Boolean()
+        prop!: boolean;
+    }
+    @Schema()
+    class Test {
+      @Nested()
+        prop!: NestedTest;
+    }
+    expect(getSchema(Test)).toEqual({
+      $$strict: false,
+      prop: {
+        type: "object",
+        strict: true,
+        props: {
+          prop: { type: "boolean" },
+        },
+      },
+    });
+  });
+
+  it("Should apply nested schema as options validator", () => {
     @Schema({ strict: true })
     class NestedTest {
       @Boolean()
@@ -503,7 +526,7 @@ describe("Nested", () => {
       @Nested({
         validator: NestedTest
       })
-        prop!: NestedTest;
+        prop?: NestedTest | null;
     }
     expect(getSchema(Test)).toEqual({
       $$strict: false,


### PR DESCRIPTION
Currently `Nested` decorator not working with nullable types.
This PR set options validator as priority. And fix this problem